### PR TITLE
Fix use preprocessor options from arguments

### DIFF
--- a/libsquoosh/src/index.ts
+++ b/libsquoosh/src/index.ts
@@ -189,16 +189,17 @@ class Image {
       else {
         preprocessorOptions = {
           ...preprocessors[preprocessorName].defaultOptions,
+          ...(options as object),
         };
-
-        this.decoded = this.workerPool.dispatchJob({
-          operation: 'preprocess',
-          preprocessorName,
-          image: await this.decoded,
-          options: preprocessorOptions,
-        });
-        await this.decoded;
       }
+
+      this.decoded = this.workerPool.dispatchJob({
+        operation: 'preprocess',
+        preprocessorName,
+        image: await this.decoded,
+        options: preprocessorOptions,
+      });
+      await this.decoded;
     }
   }
 


### PR DESCRIPTION
When using the preprocessors arguments (`--resize`, `--quant`, `--rotate`) with options (either an Object or a stringified Object), the options are not used in `Image.preprocess()`.

**To Reproduce**
Steps to reproduce the behavior:
1. Execute the command with the preprocessor option `--quant '{maxNumColors:2}'`.

**Expected behavior**
The color palette of the image is reduced to 2.

**Actual behavior**
No preprocessor is applied to the image.